### PR TITLE
Update the Read the Docs domain

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Henson-S3 |build status|
 
 A library for easily using S3 in a Henson application.
 
-* `Documentation <https://henson-s3.rtfd.org>`_
-* `Installation <https://henson-s3.readthedocs.org/en/latest/#installation>`_
-* `Changelog <https://henson-s3.readthedocs.org/en/latest/changes.html>`_
+* `Documentation <https://henson-s3.readthedocs.io>`_
+* `Installation <https://henson-s3.readthedocs.io/en/latest/#installation>`_
+* `Changelog <https://henson-s3.readthedocs.io/en/latest/changes.html>`_
 * `Source <https://github.com/dirn/Henson-S3>`_

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,7 +3,7 @@ Henson-S3
 =============
 
 Henson-S3 is a library that helps to easily interact with S3 from inside a
-`Henson <https://henson.readthedocs.org>`_ application.
+`Henson <https://henson.readthedocs.io>`_ application.
 
 Installation
 ============

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     version='0.1.0',
     author='Andy Dirnberger',
     author_email='andy@dirnberger.me',
-    url='https://henson-s3.rtfd.org',
+    url='https://henson-s3.readthedocs.io',
     description='A library for easily using S3 in a Henson application.',
     long_description=read('README.rst'),
     license='MIT',


### PR DESCRIPTION
Read the Docs has switched from using readthedocs.org to readthedocs.io
for project documentation. It includes the added benefit of having
better HTTPS support.
