### PR TITLE
Add tests

### DIFF
--- a/henson_s3.py
+++ b/henson_s3.py
@@ -40,6 +40,11 @@ class S3(Extension):
         """
         super().init_app(app)
 
+        self._session = Session(
+            aws_access_key_id=app.settings['AWS_ACCESS_KEY'],
+            aws_secret_access_key=app.settings['AWS_ACCESS_SECRET'],
+            region_name=app.settings['AWS_REGION_NAME'],
+        )
         app.startup(self._connect)
 
     async def download(self, key, *, bucket=None):
@@ -97,9 +102,4 @@ class S3(Extension):
             app (henson.base.Application): The application instance
                 against which to register the client.
         """
-        session = Session(
-            aws_access_key_id=app.settings['AWS_ACCESS_KEY'],
-            aws_secret_access_key=app.settings['AWS_ACCESS_SECRET'],
-            region_name=app.settings['AWS_REGION_NAME'],
-        )
-        self._client = session.client('s3')
+        self._client = self._session.client('s3')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,89 @@
+"""Test utilities."""
+
+from http import HTTPStatus
+import io
+
+from botocore.response import StreamingBody
+from henson import Application
+import placebo
+import pytest
+
+from henson_s3 import S3
+
+
+class MockConsumer:
+    """A stubbed consumer class."""
+
+    async def read(self):
+        """A stubbed read."""
+        return 1
+
+
+@pytest.fixture
+def s3(test_app):
+    """Return an instance of the S3 plugin."""
+    s3 = S3()
+    s3.init_app(test_app)
+
+    return s3
+
+
+@pytest.fixture
+def test_app(test_consumer, event_loop):
+    """Return a test application."""
+    async def callback(app, message):
+        raise Exception('testing')
+
+    app = Application('testing', callback=callback, consumer=test_consumer)
+    app.settings['AWS_ACCESS_KEY'] = 'testing'
+    app.settings['AWS_ACCESS_SECRET'] = 'testing'
+    app.settings['AWS_BUCKET_NAME'] = 'testing'
+    app.settings['AWS_REGION_NAME'] = 'us-east-1'
+
+    @app.message_acknowledgement
+    async def stop_loop(app, message):
+        event_loop.stop()
+
+    return app
+
+
+@pytest.fixture
+def test_consumer():
+    """Return a mock consumer."""
+    return MockConsumer()
+
+
+@pytest.fixture
+def download_session(s3, test_app, event_loop, tmpdir):
+    """Return a session with placebo attached to it."""
+    pill = placebo.attach(s3._session, data_path=str(tmpdir.dirpath()))
+
+    event_loop.run_until_complete(s3._connect(test_app))
+
+    pill.save_response(
+        service='s3',
+        operation='GetObject',
+        response_data={'Body': StreamingBody(io.StringIO('OK'), 2)},
+        http_response=HTTPStatus.OK,
+    )
+    pill.playback()
+
+    return pill
+
+
+@pytest.fixture
+def upload_session(s3, test_app, event_loop, tmpdir):
+    """Return a session with placebo attached to it."""
+    pill = placebo.attach(s3._session, data_path=str(tmpdir.dirpath()))
+
+    event_loop.run_until_complete(s3._connect(test_app))
+
+    pill.save_response(
+        service='s3',
+        operation='PutObject',
+        response_data={'Body': StreamingBody(io.StringIO('OK'), 2)},
+        http_response=HTTPStatus.OK,
+    )
+    pill.playback()
+
+    return pill

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -1,0 +1,17 @@
+"""Test Henson-S3."""
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_download(s3, download_session):
+    """Test download."""
+    actual = await s3.download('key')
+    assert actual
+
+
+@pytest.mark.asyncio
+async def test_upload(s3, upload_session):
+    """Test upload."""
+    await s3.upload('key', 'value')
+    assert True

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist = docs,pep8,py35
 [testenv]
 deps =
     coverage
+    placebo
     pytest
     pytest-asyncio
 commands =


### PR DESCRIPTION
Tests are good. I can't believe I hadn't already added them. In addition
to adding the tests, one change needs to be made to `S3`. The `Session`
instance needs to be needs to be available externally so that placebo
can intercept traffic to AWS. Fortunately creating a `Session` instance
results in no network traffic so it's safe to instantiate it in
`init_app`.
