### PR TITLE
Add response fixtures for placebo sessions

### DIFF
--- a/tests/data/placebo/download/s3.GetObject_1.json
+++ b/tests/data/placebo/download/s3.GetObject_1.json
@@ -1,0 +1,10 @@
+{
+    "status_code": 200,
+    "data": {
+        "Body": {
+            "__class__": "StreamingBody",
+            "body": "OK",
+            "__module__": "botocore.response"
+        }
+    }
+}

--- a/tests/data/placebo/upload/s3.PutObject_1.json
+++ b/tests/data/placebo/upload/s3.PutObject_1.json
@@ -1,0 +1,10 @@
+{
+    "status_code": 200,
+    "data": {
+        "Body": {
+            "__class__": "StreamingBody",
+            "body": "OK",
+            "__module__": "botocore.response"
+        }
+    }
+}


### PR DESCRIPTION
The problem with generating placebo responses as part of the test
fixtures is that each use of the fixture will generate a new placebo
response. Unless a unique `data_path` is used for each invocation of the
fixture, however, multiple responses will be written, even though only
the first will be used.

By generating the response fixture ahead of time and including it in the
respository, the unused responses won't be generated. This should also
improve the speed of the test suite (which is incredibly small, so the
tests are already about as fast as they can be) since the test fixtures
no longer have to write the files.