### PR TITLE
Add a method to check for the existence of a key

### DIFF
--- a/henson_s3.py
+++ b/henson_s3.py
@@ -47,6 +47,32 @@ class S3(Extension):
         )
         app.startup(self._connect)
 
+    async def check(self, key, *, bucket=None):
+        """Check to see if a file exists in an S3 bucket.
+
+        Args:
+            key (str): The name of the file for which to check.
+            bucket (Optional[str]): THe name of the bucket in which to
+                check for the file. If no value is provided, the
+                ``AWS_BUCKET_NAME`` setting will be used.
+
+        Returns:
+            bool: True if the file exists.
+
+        Raises:
+            ValueError: If no bucket name is specified.
+        """
+        bucket = bucket or self.app.settings['AWS_BUCKET_NAME']
+        if not bucket:
+            raise ValueError('A bucket name is required.')
+
+        try:
+            self._client.head_object(Bucket=bucket, Key=key)
+        except ClientError:
+            return False
+        else:
+            return True
+
     async def download(self, key, *, bucket=None):
         """Return the contents of a file in an S3 bucket.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,9 +57,45 @@ def test_consumer():
 
 
 @pytest.fixture
+def check_session(s3, test_app, event_loop, tmpdir):
+    """Return a session with placebo attached to it."""
+    pill = placebo.attach(s3._session, data_path=placebo_fixture('check'))
+
+    event_loop.run_until_complete(s3._connect(test_app))
+
+    pill.playback()
+
+    return pill
+
+
+@pytest.fixture
 def download_session(s3, test_app, event_loop, tmpdir):
     """Return a session with placebo attached to it."""
     pill = placebo.attach(s3._session, data_path=placebo_fixture('download'))
+
+    event_loop.run_until_complete(s3._connect(test_app))
+
+    pill.playback()
+
+    return pill
+
+
+@pytest.fixture
+def forbidden_session(s3, test_app, event_loop, tmpdir):
+    """Return a session with placebo attached to it."""
+    pill = placebo.attach(s3._session, data_path=placebo_fixture('forbidden'))
+
+    event_loop.run_until_complete(s3._connect(test_app))
+
+    pill.playback()
+
+    return pill
+
+
+@pytest.fixture
+def not_found_session(s3, test_app, event_loop, tmpdir):
+    """Return a session with placebo attached to it."""
+    pill = placebo.attach(s3._session, data_path=placebo_fixture('not_found'))
 
     event_loop.run_until_complete(s3._connect(test_app))
 

--- a/tests/data/placebo/check/s3.HeadObject_1.json
+++ b/tests/data/placebo/check/s3.HeadObject_1.json
@@ -1,0 +1,10 @@
+{
+    "status_code": 200,
+    "data": {
+        "Body": {
+            "__class__": "StreamingBody",
+            "body": "OK",
+            "__module__": "botocore.response"
+        }
+    }
+}

--- a/tests/data/placebo/forbidden/s3.HeadObject_1.json
+++ b/tests/data/placebo/forbidden/s3.HeadObject_1.json
@@ -1,0 +1,12 @@
+{
+    "data": {
+        "ResponseMetaData": {
+            "HTTPStatusCode": 403
+        },
+        "Error": {
+            "Code": 403,
+            "Message": "FORBIDDEN"
+        }
+    },
+    "status_code": 403
+}

--- a/tests/data/placebo/not_found/s3.HeadObject_1.json
+++ b/tests/data/placebo/not_found/s3.HeadObject_1.json
@@ -1,0 +1,9 @@
+{
+    "data": {
+        "Error": {
+            "Code": 404,
+            "Message": "NOT_FOUND"
+        }
+    },
+    "status_code": 404
+}

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -4,6 +4,24 @@ import pytest
 
 
 @pytest.mark.asyncio
+async def test_check(s3, check_session):
+    """Test check."""
+    assert await s3.check('key')
+
+
+@pytest.mark.asyncio
+async def test_check_forbidden(s3, forbidden_session):
+    """Test check handles forbidden files."""
+    assert not await s3.check('key')
+
+
+@pytest.mark.asyncio
+async def test_check_not_found(s3, not_found_session):
+    """Test check handles files that don't exist."""
+    assert not await s3.check('key')
+
+
+@pytest.mark.asyncio
 async def test_download(s3, download_session):
     """Test download."""
     actual = await s3.download('key')


### PR DESCRIPTION
Currently the only way for a user of Henson-S3 to know if a key already
exists on S3 is to download the file. A new coroutine (`check`) is being
added that will check for the key using a `HEAD`.

In addition to the code check, tests and the placebo responses needed
for them are being added.