### PR TITLE
Rename the AWS key access settings

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,19 +21,19 @@ Configuration
 
 The following configuration settings can be added to the application.
 
-+-----------------------+-----------------------------------------------------+
-| ``AWS_ACCESS_ID``     | The Access ID used to identify the account.         |
-|                       | Defaults to None.                                   |
-+-----------------------+-----------------------------------------------------+
-| ``AWS_ACCESS_SECRET`` | The Access Secret used to identify the account.     |
-|                       | Defaults to None.                                   |
-+-----------------------+-----------------------------------------------------+
-| ``AWS_BUCKET_NAME``   | The name of the default bucket to use. Defaults to  |
-|                       | None.                                               |
-+-----------------------+-----------------------------------------------------+
-| ``AWS_REGION_NAME``   | The name of the Region where the bucket is located. |
-|                       | Defaults to None.                                   |
-+-----------------------+-----------------------------------------------------+
++---------------------------+-------------------------------------------------+
+| ``AWS_ACCESS_KEY_ID``     | The Access ID used to identify the account.     |
+|                           | Defaults to None.                               |
++---------------------------+-------------------------------------------------+
+| ``AWS_SECRET_ACCESS_KEY`` | The Access Secret used to identify the account. |
+|                           | Defaults to None.                               |
++---------------------------+-------------------------------------------------+
+| ``AWS_BUCKET_NAME``       | The name of the default bucket to use. Defaults |
+|                           | to None.                                        |
++---------------------------+-------------------------------------------------+
+| ``AWS_REGION_NAME``       | The name of the Region where the bucket is      |
+|                           | located. Defaults to None.                      |
++---------------------------+-------------------------------------------------+
 
 Usage
 =====

--- a/henson_s3.py
+++ b/henson_s3.py
@@ -25,8 +25,8 @@ class S3(Extension):
     """A class to interact with S3."""
 
     DEFAULT_SETTINGS = {
-        'AWS_ACCESS_KEY': None,
-        'AWS_ACCESS_SECRET': None,
+        'AWS_ACCESS_KEY_ID': None,
+        'AWS_SECRET_ACCESS_KEY': None,
         'AWS_BUCKET_NAME': None,
         'AWS_REGION_NAME': None,
     }
@@ -41,8 +41,8 @@ class S3(Extension):
         super().init_app(app)
 
         self._session = Session(
-            aws_access_key_id=app.settings['AWS_ACCESS_KEY'],
-            aws_secret_access_key=app.settings['AWS_ACCESS_SECRET'],
+            aws_access_key_id=app.settings['AWS_ACCESS_KEY_ID'],
+            aws_secret_access_key=app.settings['AWS_SECRET_ACCESS_KEY'],
             region_name=app.settings['AWS_REGION_NAME'],
         )
         app.startup(self._connect)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,8 +38,8 @@ def test_app(test_consumer, event_loop):
         raise Exception('testing')
 
     app = Application('testing', callback=callback, consumer=test_consumer)
-    app.settings['AWS_ACCESS_KEY'] = 'testing'
-    app.settings['AWS_ACCESS_SECRET'] = 'testing'
+    app.settings['AWS_ACCESS_KEY_ID'] = 'testing'
+    app.settings['AWS_SECRET_ACCESS_KEY'] = 'testing'
     app.settings['AWS_BUCKET_NAME'] = 'testing'
     app.settings['AWS_REGION_NAME'] = 'us-east-1'
 


### PR DESCRIPTION
These settings are being renamed to match the names of the environment
variables AWS-related libraries and tools look for. There was also an
incorrect name used in the documentation.