### PR TITLE
Add the public API to the documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -295,4 +295,7 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'python': ('https://docs.python.org/3.5', None)}
+intersphinx_mapping = {
+    'henson': ('https://henson.readthedocs.io/en/latest/', None),
+    'python': ('https://docs.python.org/3', None),
+}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -48,6 +48,12 @@ Usage
 
     S3(app)
 
+API
+===
+
+.. autoclass:: henson_s3.S3
+   :members:
+
 Contents:
 
 .. toctree::

--- a/henson_s3.py
+++ b/henson_s3.py
@@ -52,9 +52,9 @@ class S3(Extension):
 
         Args:
             key (str): The name of the file for which to check.
-            bucket (Optional[str]): THe name of the bucket in which to
-                check for the file. If no value is provided, the
-                ``AWS_BUCKET_NAME`` setting will be used.
+            bucket (~typing.Optional[str]): THe name of the bucket in
+                which to check for the file. If no value is provided,
+                the ``AWS_BUCKET_NAME`` setting will be used.
 
         Returns:
             bool: True if the file exists.
@@ -78,8 +78,8 @@ class S3(Extension):
 
         Args:
             key (str): The name of the file to download.
-            bucket (Optional[str]): The name of the bucket from which to
-                download the file. If no value is provided, the
+            bucket (~typing.Optional[str]): The name of the bucket from
+                which to download the file. If no value is provided, the
                 ``AWS_BUCKET_NAME`` setting will be used.
 
         Returns:
@@ -108,8 +108,8 @@ class S3(Extension):
         Args:
             key (str): The name of the file to upload.
             file (bytes): The contents of the file.
-            bucket (Optional[str]): The name of the bucket to which to
-                upload the file. If no value is provided, the
+            bucket (~typing.Optional[str]): The name of the bucket to
+                which to upload the file. If no value is provided, the
                 ``AWS_BUCKET_NAME`` setting will be used.
 
         Raises:


### PR DESCRIPTION
In order for people to know how to use `S3`, it's important to include
its API in Henson-S3's documentation. In order to make the documentation
a little easier to read and keep up-to-date, the intersphinx mappings
are being updated and some of the docstrings are being updated to better
utilize `typing`.