### PR TITLE
Add Python 3.6 to the supported versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,18 @@
-# Use Python
 language: python
 
-# Run the test runner using the same version of Python we use.
-python: 3.5
+matrix:
+  include:
+    - python: 3.5
+      env: TOX_ENV=py35
+    - python: 3.6
+      env: TOX_ENV=py36
+    - python: 3.6
+      env: TOX_ENV=docs
+    - python: 3.6
+      env: TOX_ENV=pep8
 
-# Install the test runner.
 install: pip install tox
-
-# Run each environment separately so we get errors back from all of them.
-env:
-  - TOX_ENV=py35
-  - TOX_ENV=pep8
-  - TOX_ENV=docs
-script:
-  - tox -e $TOX_ENV
+script: tox -e $TOX_ENV
 
 # Control the branches that get built.
 branches:

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3 :: Only',
         'Topic :: Software Development',
     ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = docs,pep8,py35
+envlist = docs,pep8,py35,py36
 
 [testenv]
 deps =
@@ -12,14 +12,14 @@ commands =
     python -m coverage report -m --include="henson_s3.py"
 
 [testenv:docs]
-basepython = python3.5
+basepython = python3.6
 deps = -rdocs-requirements.txt
 commands =
     sphinx-build -W -b html -d {envtmpdir}/doctrees docs docs/_build/html
     doc8 --allow-long-titles README.rst docs/ --ignore-path docs/_build/
 
 [testenv:pep8]
-basepython = python3.5
+basepython = python3.6
 skip_install = True
 deps =
     flake8-docstrings


### PR DESCRIPTION
Along with listing 3.6 in `setup.py`, tox will now use it as its default
version of Python. The Travis CI configuration is being updated to use a
build matrix since 3.5 and 3.6 don't play nicely together there (the
config is also being simplified a bit to remove some of the noise).