### PR TITLE
Add Python version requirements for Pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
     license='MIT',
     py_modules=['henson_s3'],
     zip_safe=False,
+    python_requires='>=3.5',  # async/await
     install_requires=[
         'boto3',
         'Henson',


### PR DESCRIPTION
Modern versions of Pip enforce the `python_requires` argument to
`setup`. Because `async` and `await` weren't introduced until 3.5, it's
being set as the minimum required version.