### PR TITLE
Add a tox environment to perform a release

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -26,3 +26,22 @@ deps =
     pep8-naming
 commands =
     flake8 henson_s3.py
+
+; Perform a release to PyPI.
+; This will build and upload both a wheel and a source release. Additional
+; arguments can be passed to the environment. For example, to specify an
+; alternate package index (here named "test"):
+;
+;     $ python -m tox -e release -- -r test
+;
+; The upload will be signed, so make sure you have GPG configured.
+[testenv:release]
+basepython = python3.6
+skip_install = True
+whitelist_externals = rm
+deps =
+    twine
+commands =
+    rm -rf {toxinidir}/build {toxinidir}/dist
+    {envpython} setup.py build sdist bdist_wheel
+    {envpython} -m twine upload -s {toxinidir}/dist/* {posargs}


### PR DESCRIPTION
This introduces a new tox environment, `release`, that can be used to
build and upload a release to a package index. Indexes other than PyPI
can be specified by passing the `--repository` argument.

Uploads will be signed, so make sure GPG has been configured for the
user running tox.