### PR TITLE
Stop updating the copyright year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2016 Andy Dirnberger
+Copyright (c) Andy Dirnberger
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,6 +13,7 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+from datetime import date
 import sys
 import os
 import pkg_resources
@@ -54,7 +55,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'Henson-S3'
-copyright = '2016, Andy Dirnberger'
+copyright = '2016-{:%Y}, Andy Dirnberger'.format(date.today())
 author = 'Andy Dirnberger'
 
 # The version info for the project you're documenting, acts as replacement for


### PR DESCRIPTION
I don't want to have to remember to update the copyright year each time
I make a change in a new calendar year. (Obviously I failed to do that
already this year.) By removing the year completely from the LICENSE
file and letting Python set it in the documentation, I shouldn't ever
have to think about it again.