### PR TITLE
Test changes

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,7 +57,7 @@ def test_consumer():
 
 
 @pytest.fixture
-def check_session(s3, test_app, event_loop, tmpdir):
+def check_session(s3, test_app, event_loop):
     """Return a session with placebo attached to it."""
     pill = placebo.attach(s3._session, data_path=placebo_fixture('check'))
 
@@ -69,7 +69,7 @@ def check_session(s3, test_app, event_loop, tmpdir):
 
 
 @pytest.fixture
-def download_session(s3, test_app, event_loop, tmpdir):
+def download_session(s3, test_app, event_loop):
     """Return a session with placebo attached to it."""
     pill = placebo.attach(s3._session, data_path=placebo_fixture('download'))
 
@@ -81,7 +81,7 @@ def download_session(s3, test_app, event_loop, tmpdir):
 
 
 @pytest.fixture
-def forbidden_session(s3, test_app, event_loop, tmpdir):
+def forbidden_session(s3, test_app, event_loop):
     """Return a session with placebo attached to it."""
     pill = placebo.attach(s3._session, data_path=placebo_fixture('forbidden'))
 
@@ -93,7 +93,7 @@ def forbidden_session(s3, test_app, event_loop, tmpdir):
 
 
 @pytest.fixture
-def not_found_session(s3, test_app, event_loop, tmpdir):
+def not_found_session(s3, test_app, event_loop):
     """Return a session with placebo attached to it."""
     pill = placebo.attach(s3._session, data_path=placebo_fixture('not_found'))
 
@@ -105,7 +105,7 @@ def not_found_session(s3, test_app, event_loop, tmpdir):
 
 
 @pytest.fixture
-def upload_session(s3, test_app, event_loop, tmpdir):
+def upload_session(s3, test_app, event_loop):
     """Return a session with placebo attached to it."""
     pill = placebo.attach(s3._session, data_path=placebo_fixture('upload'))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,22 +80,11 @@ def download_session(s3, test_app, event_loop):
     return pill
 
 
-@pytest.fixture
-def forbidden_session(s3, test_app, event_loop):
-    """Return a session with placebo attached to it."""
-    pill = placebo.attach(s3._session, data_path=placebo_fixture('forbidden'))
-
-    event_loop.run_until_complete(s3._connect(test_app))
-
-    pill.playback()
-
-    return pill
-
-
-@pytest.fixture
-def not_found_session(s3, test_app, event_loop):
-    """Return a session with placebo attached to it."""
-    pill = placebo.attach(s3._session, data_path=placebo_fixture('not_found'))
+@pytest.fixture(params=('forbidden', 'not_found'))
+def error_session(request, s3, test_app, event_loop):
+    """Return a session that errs with placebo attached to it."""
+    pill = placebo.attach(
+        s3._session, data_path=placebo_fixture(request.param))
 
     event_loop.run_until_complete(s3._connect(test_app))
 

--- a/tests/data/placebo/forbidden/s3.GetObject_1.json
+++ b/tests/data/placebo/forbidden/s3.GetObject_1.json
@@ -1,0 +1,12 @@
+{
+    "data": {
+        "ResponseMetaData": {
+            "HTTPStatusCode": 403
+        },
+        "Error": {
+            "Code": 403,
+            "Message": "FORBIDDEN"
+        }
+    },
+    "status_code": 403
+}

--- a/tests/data/placebo/not_found/s3.GetObject_1.json
+++ b/tests/data/placebo/not_found/s3.GetObject_1.json
@@ -1,0 +1,9 @@
+{
+    "data": {
+        "Error": {
+            "Code": 404,
+            "Message": "NOT_FOUND"
+        }
+    },
+    "status_code": 404
+}

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -10,14 +10,8 @@ async def test_check(s3, check_session):
 
 
 @pytest.mark.asyncio
-async def test_check_forbidden(s3, forbidden_session):
-    """Test check handles forbidden files."""
-    assert not await s3.check('key')
-
-
-@pytest.mark.asyncio
-async def test_check_not_found(s3, not_found_session):
-    """Test check handles files that don't exist."""
+async def test_check_errors(s3, error_session):
+    """Test check handles errors."""
     assert not await s3.check('key')
 
 

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -23,6 +23,13 @@ async def test_download(s3, download_session):
 
 
 @pytest.mark.asyncio
+async def test_download_filenotfounderror(s3, error_session):
+    """Test that download raises FileNotFoundError."""
+    with pytest.raises(FileNotFoundError):
+        await s3.download('key')
+
+
+@pytest.mark.asyncio
 async def test_upload(s3, upload_session):
     """Test upload."""
     await s3.upload('key', 'value')


### PR DESCRIPTION
These changes will stop passing the unused `tmpdir` fixture to the session
fixtures. They will also reduce the number of fixture sessions needed, along
with the number of test functions needed to test errors, an additional one of
which is being added to test errors when calling `download`.