### PR TITLE
Rename to Doozer-S3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@ Version 0.2.0
 
 Release TBD
 
+- Renamed to Doozer-S3
+
 Version 0.1.0
 -------------
 

--- a/README.rst
+++ b/README.rst
@@ -1,13 +1,13 @@
 ========================
-Henson-S3 |build status|
+Doozer-S3 |build status|
 ========================
 
-.. |build status| image:: https://travis-ci.org/dirn/Henson-S3.svg?branch=master
-   :target: https://travis-ci.org/dirn/Henson-S3
+.. |build status| image:: https://travis-ci.org/dirn/Doozer-S3.svg?branch=master
+   :target: https://travis-ci.org/dirn/Doozer-S3
 
-A library for easily using S3 in a Henson application.
+A library for easily using S3 in a Doozer application.
 
-* `Documentation <https://henson-s3.readthedocs.io>`_
-* `Installation <https://henson-s3.readthedocs.io/en/latest/#installation>`_
-* `Changelog <https://henson-s3.readthedocs.io/en/latest/changes.html>`_
-* `Source <https://github.com/dirn/Henson-S3>`_
+* `Documentation <https://doozer-s3.readthedocs.io>`_
+* `Installation <https://doozer-s3.readthedocs.io/en/latest/#installation>`_
+* `Changelog <https://doozer-s3.readthedocs.io/en/latest/changes.html>`_
+* `Source <https://github.com/dirn/Doozer-S3>`_

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -95,9 +95,9 @@ qthelp:
 	@echo
 	@echo "Build finished; now you can run "qcollectiongenerator" with the" \
 	      ".qhcp project file in $(BUILDDIR)/qthelp, like this:"
-	@echo "# qcollectiongenerator $(BUILDDIR)/qthelp/Henson-S3.qhcp"
+	@echo "# qcollectiongenerator $(BUILDDIR)/qthelp/Doozer-S3.qhcp"
 	@echo "To view the help file:"
-	@echo "# assistant -collectionFile $(BUILDDIR)/qthelp/Henson-S3.qhc"
+	@echo "# assistant -collectionFile $(BUILDDIR)/qthelp/Doozer-S3.qhc"
 
 .PHONY: applehelp
 applehelp:
@@ -114,8 +114,8 @@ devhelp:
 	@echo
 	@echo "Build finished."
 	@echo "To view the help file:"
-	@echo "# mkdir -p $$HOME/.local/share/devhelp/Henson-S3"
-	@echo "# ln -s $(BUILDDIR)/devhelp $$HOME/.local/share/devhelp/Henson-S3"
+	@echo "# mkdir -p $$HOME/.local/share/devhelp/Doozer-S3"
+	@echo "# ln -s $(BUILDDIR)/devhelp $$HOME/.local/share/devhelp/Doozer-S3"
 	@echo "# devhelp"
 
 .PHONY: epub

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Henson-S3 documentation build configuration file, created by
+# Doozer-S3 documentation build configuration file, created by
 # sphinx-quickstart on Thu Mar 31 23:53:49 2016.
 #
 # This file is execfile()d with the current directory set to its
@@ -54,7 +54,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = 'Henson-S3'
+project = 'Doozer-S3'
 copyright = '2016-{:%Y}, Andy Dirnberger'.format(date.today())
 author = 'Andy Dirnberger'
 
@@ -63,7 +63,7 @@ author = 'Andy Dirnberger'
 # built documents.
 #
 # The full version, including alpha/beta/rc tags.
-release = pkg_resources.get_distribution('henson-s3').version
+release = pkg_resources.get_distribution('doozer-s3').version
 # The short X.Y version.
 version = release.rsplit('.', 1)[0]
 
@@ -129,7 +129,7 @@ html_theme = 'sphinx_rtd_theme'
 
 # The name for this set of Sphinx documents.
 # "<project> v<release> documentation" by default.
-#html_title = 'Henson-S3 v0.1.0'
+#html_title = 'Doozer-S3 v0.1.0'
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
 #html_short_title = None
@@ -211,7 +211,7 @@ html_static_path = ['_static']
 #html_search_scorer = 'scorer.js'
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'Henson-S3doc'
+htmlhelp_basename = 'Doozer-S3doc'
 
 # -- Options for LaTeX output ---------------------------------------------
 
@@ -233,7 +233,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'Henson-S3.tex', 'Henson-S3 Documentation',
+    (master_doc, 'Doozer-S3.tex', 'Doozer-S3 Documentation',
      'Andy Dirnberger', 'manual'),
 ]
 
@@ -263,7 +263,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'henson-s3', 'Henson-S3 Documentation',
+    (master_doc, 'doozer-s3', 'Doozer-S3 Documentation',
      [author], 1)
 ]
 
@@ -277,8 +277,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'Henson-S3', 'Henson-S3 Documentation',
-     author, 'Henson-S3', 'One line description of project.',
+    (master_doc, 'Doozer-S3', 'Doozer-S3 Documentation',
+     author, 'Doozer-S3', 'One line description of project.',
      'Miscellaneous'),
 ]
 
@@ -297,6 +297,6 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    'henson': ('https://henson.readthedocs.io/en/latest/', None),
+    'doozer': ('https://doozer.readthedocs.io/en/latest/', None),
     'python': ('https://docs.python.org/3', None),
 }

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,20 +1,20 @@
-=============
-Henson-S3
-=============
+=========
+Doozer-S3
+=========
 
-Henson-S3 is a library that helps to easily interact with S3 from inside a
-`Henson <https://henson.readthedocs.io>`_ application.
+Doozer-S3 is a library that helps to easily interact with S3 from inside a
+`Doozer <https://doozer.readthedocs.io>`_ application.
 
 Installation
 ============
 
-Henson-S3 can be installed with::
+Doozer-S3 can be installed with::
 
-    $ python -m pip install Henson-S3
+    $ python -m pip install Doozer-S3
 
 .. warning::
 
-    Henson-S3 is not yet available on the Python Package Index.
+    Doozer-S3 is not yet available on the Python Package Index.
 
 Configuration
 =============
@@ -40,18 +40,18 @@ Usage
 
 .. code::
 
-    from henson import Application
-    from henson_s3 import S3
+    from doozer import Application
+    from doozer_s3 import S3
 
     app = Application('application-with-s3')
-    app.settings['AWS_BUCKET_NAME'] = 'my-henson-bucket'
+    app.settings['AWS_BUCKET_NAME'] = 'my-doozer-bucket'
 
     S3(app)
 
 API
 ===
 
-.. autoclass:: henson_s3.S3
+.. autoclass:: doozer_s3.S3
    :members:
 
 Contents:

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -128,9 +128,9 @@ if "%1" == "qthelp" (
 	echo.
 	echo.Build finished; now you can run "qcollectiongenerator" with the ^
 .qhcp project file in %BUILDDIR%/qthelp, like this:
-	echo.^> qcollectiongenerator %BUILDDIR%\qthelp\Henson-S3.qhcp
+	echo.^> qcollectiongenerator %BUILDDIR%\qthelp\Doozer-S3.qhcp
 	echo.To view the help file:
-	echo.^> assistant -collectionFile %BUILDDIR%\qthelp\Henson-S3.ghc
+	echo.^> assistant -collectionFile %BUILDDIR%\qthelp\Doozer-S3.ghc
 	goto end
 )
 

--- a/doozer_s3.py
+++ b/doozer_s3.py
@@ -1,11 +1,11 @@
-"""A Henson plugin to interact with S3."""
+"""A Doozer plugin to interact with S3."""
 
 import os as _os
 import pkg_resources as _pkg_resources
 
 from boto3.session import Session
 from botocore.exceptions import ClientError
-from henson import Extension
+from doozer import Extension
 
 __all__ = ('S3',)
 
@@ -35,7 +35,7 @@ class S3(Extension):
         """Initialize an ``Application`` instance.
 
         Args:
-            app (henson.base.Application): The application instance to
+            app (doozer.base.Application): The application instance to
                 be initialized.
         """
         super().init_app(app)
@@ -125,7 +125,7 @@ class S3(Extension):
         """Create an S3 client.
 
         Args:
-            app (henson.base.Application): The application instance
+            app (doozer.base.Application): The application instance
                 against which to register the client.
         """
         self._client = self._session.client('s3')

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[flake8]
+ignore = D413

--- a/setup.py
+++ b/setup.py
@@ -19,20 +19,20 @@ def read(filename):
         return f.read()
 
 setup(
-    name='Henson-S3',
+    name='Doozer-S3',
     version='0.2.0',
     author='Andy Dirnberger',
     author_email='andy@dirnberger.me',
-    url='https://henson-s3.readthedocs.io',
-    description='A library for easily using S3 in a Henson application.',
+    url='https://doozer-s3.readthedocs.io',
+    description='A library for easily using S3 in a Doozer application.',
     long_description=read('README.rst'),
     license='MIT',
-    py_modules=['henson_s3'],
+    py_modules=['doozer_s3'],
     zip_safe=False,
     python_requires='>=3.5',  # async/await
     install_requires=[
         'boto3',
-        'Henson',
+        'Doozer',
     ],
     tests_require=[
         'pytest',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,11 +3,11 @@
 from functools import partial
 import os
 
-from henson import Application
+from doozer import Application
 import placebo
 import pytest
 
-from henson_s3 import S3
+from doozer_s3 import S3
 
 
 placebo_fixture = partial(

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -1,4 +1,4 @@
-"""Test Henson-S3."""
+"""Test Doozer-S3."""
 
 import pytest
 

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ deps =
     pytest-asyncio
 commands =
     python -m coverage run -m pytest --strict {posargs: tests}
-    python -m coverage report -m --include="henson_s3.py"
+    python -m coverage report -m --include="doozer_s3.py"
 
 [testenv:docs]
 basepython = python3.6
@@ -25,7 +25,7 @@ deps =
     flake8-docstrings
     pep8-naming
 commands =
-    flake8 henson_s3.py
+    flake8 doozer_s3.py
 
 ; Perform a release to PyPI.
 ; This will build and upload both a wheel and a source release. Additional


### PR DESCRIPTION
This project will evolve with Doozer, a community-owned fork of Henson.
As such the name is being changed to reflect that. While there are no
plans to break compatibility with Henson (via doozerify), it may happen
if an incompatible change is deemed beneficial to Doozer-S3.

Signed-off-by: Andy Dirnberger <andy@dirnberger.me>